### PR TITLE
Improve theme colors

### DIFF
--- a/src/css/secoes/footer.css
+++ b/src/css/secoes/footer.css
@@ -2,7 +2,7 @@
 .footer {
     margin-top: 7rem;
     text-align: center;
-    background-color: rgba(10, 25, 47, 0.5);
+    background-color: var(--cor-overlay-footer);
 }
 
 .footer .container {

--- a/src/css/secoes/header.css
+++ b/src/css/secoes/header.css
@@ -1,6 +1,6 @@
 .header {
     padding: 30px 15px;
-    background-color: rgba(10, 25, 47, 0.9);
+    background-color: var(--cor-overlay);
     position: fixed;
     top: 0;
     width: 100%;
@@ -150,7 +150,7 @@
 
    .header nav ul {
         display: none;
-        background-color: rgba(10, 25, 47, 0.9);
+        background-color: var(--cor-overlay);
         padding: 20px;
     }
     

--- a/src/css/secoes/projetos.css
+++ b/src/css/secoes/projetos.css
@@ -34,7 +34,7 @@
 
 .projetos .container-projetos .projeto .informacoes-projeto {
     padding: 20px 20px;
-    background-color: rgba(10, 25, 47, 0.9);
+    background-color: var(--cor-overlay);
     position: absolute;
     top: 0;
     width: 100%;

--- a/src/css/variaveis.css
+++ b/src/css/variaveis.css
@@ -1,4 +1,18 @@
 :root {
+  /* light theme colors */
+  --cor-primaria: #64ffda;
+  --cor-secundaria: #8892b0;
+  --cor-branca: #0a192f;
+  --cor-fundo-escuro: #ffffff;
+  --cor-fundo-azul-escuro: #dfe7ef;
+  --cor-hoover-habilidades: #64ffda;
+  --cor-fundo-azul-claro: #f0f4f8;
+  --cor-overlay: rgba(255, 255, 255, 0.9);
+  --cor-overlay-footer: rgba(255, 255, 255, 0.5);
+}
+
+body.dark {
+  /* dark theme overrides */
   --cor-primaria: #64ffda;
   --cor-secundaria: #8892b0;
   --cor-branca: #e6f1ff;
@@ -6,6 +20,8 @@
   --cor-fundo-azul-escuro: #020c1b;
   --cor-hoover-habilidades: #64ffda;
   --cor-fundo-azul-claro: #112240;
+  --cor-overlay: rgba(10, 25, 47, 0.9);
+  --cor-overlay-footer: rgba(10, 25, 47, 0.5);
 }
 
 :root {


### PR DESCRIPTION
## Summary
- add color overrides for light and dark themes
- replace hardcoded overlay colors with CSS variables

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6868385a5bcc83268b8c46e44ab42e30